### PR TITLE
Add locations for Augsburg: /agb /aux

### DIFF
--- a/conf.d/agb.conf
+++ b/conf.d/agb.conf
@@ -1,0 +1,3 @@
+location ~* ^/agb {
+	return 302 https://inventory.openlab-augsburg.de/$request_uri;
+}

--- a/conf.d/aux.conf
+++ b/conf.d/aux.conf
@@ -1,0 +1,3 @@
+location ~* ^/aux {
+	return 302 https://urn.fbau.org/$request_uri;
+}


### PR DESCRIPTION
Hi,

I'd like to claim the /agb (IATA) namespace prefix for Chaostreff/OpenLab Augsburg.

Similarly /aux for a small warehouse/garage's inventory space. 

Side question: Would it be a good idea to align the matching strategy of all nginx http locations across files? I don't strictly see a need for regex matching yet, do you? I'd think we could prefer returning code 302 rather than 301, to allow more flexible/dynamic server side changes.

Thx & Cheers,
krobin